### PR TITLE
Add AGENTS instructions for docs reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# Agent Instructions
+
+- Always review `README.md` and the documents in the `docs/` directory when making changes in this repository.
+- Use these files as references for project conventions, style, and usage.
+- Ensure new contributions remain consistent with the guidance provided in those documents.
+


### PR DESCRIPTION
## Summary
- Add AGENTS instructions to consult README.md and docs when contributing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run backend:test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a559f53f6c8333950f04053775161c