### PR TITLE
test: configure vitest with smoke tests for main routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest",
     "backend:install": "python -m pip install -r backend/requirements.txt",
     "backend:dev": "python -m uvicorn backend.app.main:app --host 127.0.0.1 --port 8000 --env-file backend/.env",
     "backend:alembic:upgrade": "python -m alembic -c backend/alembic.ini upgrade head",
@@ -43,6 +44,10 @@
     "eslint": "^9",
     "eslint-config-next": "15.4.6",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^1.0.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.0.0",
+    "jsdom": "^23.0.0"
   }
 }

--- a/src/__tests__/caja.test.tsx
+++ b/src/__tests__/caja.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import Caja from '@/components/pos/dashboard/caja';
+import { I18nProvider } from '@/lib/i18n';
+
+describe('Caja', () => {
+  it('renders without crashing', () => {
+    render(
+      <I18nProvider>
+        <Caja licenseState="active" />
+      </I18nProvider>
+    );
+    expect(screen.getByText(/Órdenes finalizadas/i)).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/catalogo.test.tsx
+++ b/src/__tests__/catalogo.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import CatalogoView from '@/components/pos/catalogo';
+import { I18nProvider } from '@/lib/i18n';
+import type { CatalogItem } from '@/types/pos';
+
+describe('Catalogo', () => {
+  it('renders without crashing', () => {
+    const Wrapper = () => {
+      const [catalog, setCatalog] = React.useState<CatalogItem[]>([]);
+      return (
+        <I18nProvider>
+          <CatalogoView catalog={catalog} setCatalog={setCatalog} />
+        </I18nProvider>
+      );
+    };
+    render(<Wrapper />);
+    expect(screen.getByText(/Catálogo/i)).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/clientes.test.tsx
+++ b/src/__tests__/clientes.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import ClientesView from '@/components/pos/clientes';
+import type { Cliente } from '@/types/pos';
+
+describe('Clientes', () => {
+  it('renders without crashing', () => {
+    const Wrapper = () => {
+      const [clientes, setClientes] = React.useState<Cliente[]>([
+        { id: 'c1', nombre: 'Ana', telefono: '555' },
+      ]);
+      return <ClientesView clientes={clientes} setClientes={setClientes} />;
+    };
+    render(<Wrapper />);
+    expect(screen.getByText(/Clientes/i)).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/configuracion.test.tsx
+++ b/src/__tests__/configuracion.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import ConfiguracionView from '@/components/pos/configuracion';
+
+describe('Configuracion', () => {
+  it('renders without crashing', () => {
+    render(<ConfiguracionView />);
+    expect(screen.getByText(/Información del taller/i)).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/cotizacion.test.tsx
+++ b/src/__tests__/cotizacion.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import Cotizacion from '@/components/pos/taller/cotizacion';
+import { I18nProvider } from '@/lib/i18n';
+import type { CatalogItem, Cliente, Vehiculo } from '@/types/pos';
+
+describe('Cotizacion', () => {
+  it('renders without crashing', () => {
+    const catalog: CatalogItem[] = [{ id: 'it1', nombre: 'Aceite', precio: 100, tipo: 'Servicio' }];
+    const clientes: Cliente[] = [{ id: 'c1', nombre: 'Juan', telefono: '123' }];
+    const vehiculos: Vehiculo[] = [{ id: 'v1', desc: 'Auto', clienteId: 'c1' }];
+    render(
+      <I18nProvider>
+        <Cotizacion catalog={catalog} clientes={clientes} vehiculos={vehiculos} />
+      </I18nProvider>
+    );
+    expect(screen.getByText(/Resumen de cotización/i)).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/dashboard.test.tsx
+++ b/src/__tests__/dashboard.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react';
+import Dashboard from '@/components/pos/dashboard';
+import React from 'react';
+
+describe('Dashboard', () => {
+  it('renders without crashing', () => {
+    render(<Dashboard licenseState="active" />);
+    expect(screen.getByText(/Ingresos de hoy/i)).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/ordenes.test.tsx
+++ b/src/__tests__/ordenes.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import OrdenesTrabajo from '@/components/pos/taller/ordenes';
+
+describe('Ordenes', () => {
+  it('renders without crashing', () => {
+    render(<OrdenesTrabajo />);
+    expect(screen.getByText('Pendiente')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/vehiculos.test.tsx
+++ b/src/__tests__/vehiculos.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import VehiculosView from '@/components/pos/vehiculos';
+import type { Vehiculo, Cliente } from '@/types/pos';
+
+describe('Vehiculos', () => {
+  it('renders without crashing', () => {
+    const Wrapper = () => {
+      const [vehiculos, setVehiculos] = React.useState<Vehiculo[]>([
+        { id: 'v1', desc: 'Auto', clienteId: 'c1' },
+      ]);
+      const [clientes] = React.useState<Cliente[]>([
+        { id: 'c1', nombre: 'Ana', telefono: '555' },
+      ]);
+      return (
+        <VehiculosView
+          vehiculos={vehiculos}
+          setVehiculos={setVehiculos}
+          clientes={clientes}
+        />
+      );
+    };
+    render(<Wrapper />);
+    expect(screen.getByText(/Vehículos/i)).toBeInTheDocument();
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
         "name": "next"
       }
     ],
+    "types": ["vitest/globals", "node"],
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './vitest.setup.ts',
+  },
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
+  esbuild: {
+    jsx: 'automatic',
+  },
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,23 @@
+import React from 'react';
+import { vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+
+class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+// @ts-ignore
+vi.stubGlobal('ResizeObserver', ResizeObserver);
+
+// Basic fetch stub returning empty arrays
+vi.stubGlobal('fetch', vi.fn(() =>
+  Promise.resolve({ json: () => Promise.resolve([]) }) as any
+));
+
+vi.mock('next/image', () => ({
+  default: (props: any) => {
+    const { src, alt, ...rest } = props;
+    return React.createElement('img', { src: typeof src === 'string' ? src : src.src, alt, ...rest });
+  },
+}));


### PR DESCRIPTION
## Summary
- configure Vitest and Testing Library
- add smoke tests for dashboard, cotización, órdenes, caja, catálogo, clientes, vehículos and configuración components

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint`
- `npm run typecheck` *(fails: Cannot find type definition file for 'vitest/globals')*

------
https://chatgpt.com/codex/tasks/task_e_68a55efa0d3c833384cf6e74d65f6264