### PR TITLE
feat: add role-based access control

### DIFF
--- a/backend/app/billing.py
+++ b/backend/app/billing.py
@@ -1,6 +1,8 @@
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Request, Depends
 from pydantic import BaseModel
 from typing import Literal
+
+from .auth import require_roles
 
 
 router = APIRouter(prefix="/portal/api/billing", tags=["billing"])
@@ -19,7 +21,10 @@ class SubscriptionResponse(BaseModel):
 
 
 @router.post("/subscribe", response_model=SubscriptionResponse)
-def subscribe(payload: SubscriptionRequest):
+def subscribe(
+    payload: SubscriptionRequest,
+    claims: dict = Depends(require_roles(["admin"])),
+):
     """Crea una suscripción para el cliente indicado."""
     return SubscriptionResponse(
         customer_id=payload.customer_id,
@@ -29,7 +34,10 @@ def subscribe(payload: SubscriptionRequest):
 
 
 @router.post("/cancel", response_model=SubscriptionResponse)
-def cancel(payload: SubscriptionRequest):
+def cancel(
+    payload: SubscriptionRequest,
+    claims: dict = Depends(require_roles(["admin"])),
+):
     """Cancela la suscripción del cliente."""
     return SubscriptionResponse(
         customer_id=payload.customer_id,

--- a/backend/app/cfdi.py
+++ b/backend/app/cfdi.py
@@ -1,8 +1,9 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 from uuid import uuid4
 
 from .storage import upload_bytes
+from .auth import require_roles
 
 router = APIRouter(prefix="/cfdi", tags=["cfdi"])
 
@@ -26,7 +27,10 @@ class CfdiResponse(BaseModel):
 
 
 @router.post("/", response_model=CfdiResponse)
-def generate_cfdi(payload: CfdiRequest) -> CfdiResponse:
+def generate_cfdi(
+    payload: CfdiRequest,
+    claims: dict = Depends(require_roles(["admin"])),
+) -> CfdiResponse:
     uuid = uuid4().hex
     total = sum(i.quantity * i.unit_price for i in payload.items)
     items_xml = "".join(

--- a/backend/tests/test_cfdi.py
+++ b/backend/tests/test_cfdi.py
@@ -1,5 +1,10 @@
+from datetime import datetime, timedelta, timezone
+
 from fastapi.testclient import TestClient
+from jose import jwt
+
 from backend.app.main import app
+from backend.app.auth import SECRET, ALGO
 import os
 
 
@@ -8,11 +13,18 @@ def test_generate_cfdi(tmp_path, monkeypatch):
     monkeypatch.setenv("S3_ENDPOINT", "")
     monkeypatch.setenv("S3_LOCAL_DIR", str(tmp_path))
     client = TestClient(app)
+    now = datetime.now(timezone.utc)
+    token = jwt.encode(
+        {"sub": "tester", "roles": ["admin"], "exp": int((now + timedelta(hours=1)).timestamp())},
+        SECRET,
+        algorithm=ALGO,
+    )
+    headers = {"Authorization": f"Bearer {token}"}
     payload = {
         "customer": "ACME",
         "items": [{"description": "Servicio", "quantity": 1, "unit_price": 100.0}],
     }
-    resp = client.post("/cfdi/", json=payload)
+    resp = client.post("/cfdi/", json=payload, headers=headers)
     assert resp.status_code == 200
     data = resp.json()
     assert data["uuid"]

--- a/backend/tests/test_rbac.py
+++ b/backend/tests/test_rbac.py
@@ -1,0 +1,39 @@
+from datetime import datetime, timedelta, timezone
+
+from fastapi.testclient import TestClient
+from jose import jwt
+
+from backend.app.main import app
+from backend.app.auth import SECRET, ALGO
+
+
+def make_token(roles):
+    now = datetime.now(timezone.utc)
+    return jwt.encode(
+        {"sub": "tester", "roles": roles, "exp": int((now + timedelta(hours=1)).timestamp())},
+        SECRET,
+        algorithm=ALGO,
+    )
+
+
+def test_cfdi_forbidden_for_non_admin(tmp_path, monkeypatch):
+    monkeypatch.setenv("S3_ENDPOINT", "")
+    monkeypatch.setenv("S3_LOCAL_DIR", str(tmp_path))
+    client = TestClient(app)
+    token = make_token(["user"])
+    payload = {
+        "customer": "ACME",
+        "items": [{"description": "Servicio", "quantity": 1, "unit_price": 100.0}],
+    }
+    r = client.post("/cfdi/", json=payload, headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 403
+
+
+def test_billing_subscribe_requires_admin():
+    client = TestClient(app)
+    token = make_token(["user"])
+    payload = {"customer_id": "c1", "plan_id": "p1"}
+    r = client.post(
+        "/portal/api/billing/subscribe", json=payload, headers={"Authorization": f"Bearer {token}"}
+    )
+    assert r.status_code == 403

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,4 +1,20 @@
-export { default } from 'next-auth/middleware'
+import { withAuth } from 'next-auth/middleware'
+import { NextResponse } from 'next/server'
+
+export default withAuth(
+  function middleware(req) {
+    const roles = (req.nextauth.token?.roles as string[]) || []
+    if (!roles.includes('admin')) {
+      return NextResponse.redirect(new URL('/', req.url))
+    }
+    return NextResponse.next()
+  },
+  {
+    callbacks: {
+      authorized: ({ token }) => !!token,
+    },
+  },
+)
 
 export const config = {
   matcher: ['/dashboard/:path*'],

--- a/src/__tests__/configuracion.test.tsx
+++ b/src/__tests__/configuracion.test.tsx
@@ -1,9 +1,15 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import ConfiguracionView from '@/components/pos/configuracion';
+import { useSession } from 'next-auth/react';
+
+vi.mock('next-auth/react', () => ({
+  useSession: vi.fn(),
+}));
 
 describe('Configuracion', () => {
-  it('renders without crashing', () => {
+  it('renders for admin role', () => {
+    (useSession as any).mockReturnValue({ data: { roles: ['admin'] } });
     render(<ConfiguracionView />);
     expect(screen.getByText(/Información del taller/i)).toBeInTheDocument();
   });

--- a/src/__tests__/dashboard.test.tsx
+++ b/src/__tests__/dashboard.test.tsx
@@ -1,9 +1,21 @@
 import { render, screen } from '@testing-library/react';
 import Dashboard from '@/components/pos/dashboard';
 import React from 'react';
+import { useSession } from 'next-auth/react';
 
-describe('Dashboard', () => {
-  it('renders without crashing', () => {
+vi.mock('next-auth/react', () => ({
+  useSession: vi.fn(),
+}));
+
+describe('Dashboard RBAC', () => {
+  it('denies access without admin role', () => {
+    (useSession as any).mockReturnValue({ data: { roles: ['user'] } });
+    render(<Dashboard licenseState="active" />);
+    expect(screen.getByText(/Acceso denegado/i)).toBeInTheDocument();
+  });
+
+  it('renders for admin role', () => {
+    (useSession as any).mockReturnValue({ data: { roles: ['admin'] } });
     render(<Dashboard licenseState="active" />);
     expect(screen.getByText(/Ingresos de hoy/i)).toBeInTheDocument();
   });

--- a/src/components/pos/configuracion.tsx
+++ b/src/components/pos/configuracion.tsx
@@ -2,8 +2,14 @@
 
 import React from "react";
 import { Building, KeyRound } from "lucide-react";
+import { useSession } from "next-auth/react";
+import { hasRole } from "@/lib/utils";
 
 export default function ConfiguracionView() {
+  const { data } = useSession();
+  if (!hasRole(data?.roles, "admin")) {
+    return <div>Acceso denegado</div>;
+  }
   return (
     <div className="p-4 md:p-6 space-y-4">
       <div className="rounded-2xl border bg-white p-4">

--- a/src/components/pos/dashboard.tsx
+++ b/src/components/pos/dashboard.tsx
@@ -22,6 +22,8 @@ import {
 
 import { PALETTE, currency } from "./constants";
 import { LicenseState } from "@/types/pos";
+import { useSession } from "next-auth/react";
+import { hasRole } from "@/lib/utils";
 
 function licenseBadge(state: LicenseState) {
   const map: Record<LicenseState, { label: string; className: string }> = {
@@ -68,6 +70,10 @@ function KpiCard({ title, value, foot }: { title: string; value: string; foot?: 
 }
 
 export default function Dashboard({ licenseState }: { licenseState: LicenseState }) {
+  const { data } = useSession();
+  if (!hasRole(data?.roles, "admin")) {
+    return <div>Acceso denegado</div>;
+  }
   const lic = licenseBadge(licenseState);
   const storageUsedPct = 62;
   const approvalsPend = 3;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -6,3 +6,11 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
+export function hasRole(
+  roles: string[] | undefined,
+  required: string | string[],
+): boolean {
+  const list = Array.isArray(required) ? required : [required];
+  return Array.isArray(roles) && list.some((r) => roles.includes(r));
+}
+


### PR DESCRIPTION
## Summary
- secure FastAPI endpoints with require_roles dependency
- gate admin dashboard routes and components via middleware & hasRole helper
- test RBAC for API and dashboard access

## Testing
- `pytest backend/tests/test_rbac.py backend/tests/test_cfdi.py -q`
- `pytest backend -q`
- `npx vitest src/__tests__/dashboard.test.tsx src/__tests__/configuracion.test.tsx --run` *(fails: Cannot find module 'vitest/config')*


------
https://chatgpt.com/codex/tasks/task_e_68a57dd3651483338e6c34e3422b768c