### PR TITLE
feat: add CFDI document persistence and download

### DIFF
--- a/backend/alembic/versions/20250818_0005_add_cfdi_documents.py
+++ b/backend/alembic/versions/20250818_0005_add_cfdi_documents.py
@@ -1,0 +1,32 @@
+"""add cfdi documents table
+
+Revision ID: 20250818_0005
+Revises: 20250818_0004
+Create Date: 2025-08-20 00:00:00.000000
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '20250818_0005'
+down_revision = '20250818_0004'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'cfdi_documents',
+        sa.Column('uuid', sa.String(length=32), nullable=False),
+        sa.Column('customer', sa.String(length=255), nullable=False),
+        sa.Column('total', sa.Float(), nullable=False),
+        sa.Column('xml_url', sa.String(length=1024), nullable=False),
+        sa.Column('pdf_url', sa.String(length=1024), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint('uuid')
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('cfdi_documents')

--- a/backend/app/cfdi.py
+++ b/backend/app/cfdi.py
@@ -1,9 +1,19 @@
-from fastapi import APIRouter, Depends
 from pydantic import BaseModel
+from datetime import datetime, timezone
+import hashlib
 from uuid import uuid4
+from xml.etree.ElementTree import Element, SubElement, tostring
+from urllib.parse import urlparse
 
-from .storage import upload_bytes
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import FileResponse, RedirectResponse
+from sqlalchemy.orm import Session
+
 from .auth import require_roles
+from .db import get_db
+from .models import CfdiDocumentORM
+from .storage import upload_bytes
+
 
 router = APIRouter(prefix="/cfdi", tags=["cfdi"])
 
@@ -26,23 +36,99 @@ class CfdiResponse(BaseModel):
     status: str = "generated"
 
 
+def _build_xml(uuid: str, customer: str, items: list[Item], total: float) -> bytes:
+    sello = hashlib.sha256(uuid.encode()).hexdigest()
+    timbre = hashlib.md5(uuid.encode()).hexdigest()
+    root = Element(
+        "cfdi",
+        uuid=uuid,
+        customer=customer,
+        total=f"{total:.2f}",
+        sello=sello,
+        timbre=timbre,
+        fecha=datetime.now(timezone.utc).isoformat(),
+    )
+    for i in items:
+        SubElement(
+            root,
+            "item",
+            desc=i.description,
+            qty=str(i.quantity),
+            price=f"{i.unit_price:.2f}",
+        )
+    return tostring(root, encoding="utf-8", xml_declaration=True)
+
+
+def _build_pdf(uuid: str, customer: str, total: float) -> bytes:
+    text = f"CFDI {uuid} \nCliente: {customer} \nTotal: {total:.2f}"
+    # Minimal PDF with text, enough for tests and manual inspection
+    content = f"BT /F1 12 Tf 72 720 Td ({text}) Tj ET"
+    parts = [
+        "%PDF-1.4",
+        "1 0 obj<< /Type /Catalog /Pages 2 0 R >>endobj",
+        "2 0 obj<< /Type /Pages /Kids [3 0 R] /Count 1 >>endobj",
+        "3 0 obj<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>endobj",
+        f"4 0 obj<< /Length {len(content)} >>stream\n{content}\nendstream\nendobj",
+        "5 0 obj<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>endobj",
+    ]
+    xref_positions = []
+    offset = 0
+    for part in parts:
+        xref_positions.append(offset)
+        offset += len(part.encode("utf-8")) + 1
+    xref_start = offset
+    xref = ["xref", "0 6", "0000000000 65535 f "]
+    for pos in xref_positions:
+        xref.append(f"{pos:010} 00000 n ")
+    trailer = "trailer<< /Size 6 /Root 1 0 R >>\nstartxref\n{}\n%%EOF".format(xref_start)
+    pdf_bytes = ("\n".join(parts) + "\n" + "\n".join(xref) + "\n" + trailer).encode("utf-8")
+    return pdf_bytes
+
+
+def _serve_url(url: str, filename: str, media_type: str):
+    if url.startswith("file://"):
+        path = urlparse(url).path
+        return FileResponse(path, media_type=media_type, filename=filename)
+    return RedirectResponse(url)
+
+
 @router.post("/", response_model=CfdiResponse)
 def generate_cfdi(
     payload: CfdiRequest,
+    db: Session = Depends(get_db),
     claims: dict = Depends(require_roles(["admin"])),
 ) -> CfdiResponse:
     uuid = uuid4().hex
     total = sum(i.quantity * i.unit_price for i in payload.items)
-    items_xml = "".join(
-        f"<item desc='{i.description}' qty='{i.quantity}' price='{i.unit_price}'/>"
-        for i in payload.items
-    )
-    xml_content = f"<cfdi uuid='{uuid}' customer='{payload.customer}' total='{total}'>{items_xml}</cfdi>"
-    pdf_content = (
-        f"CFDI {uuid}\nCliente: {payload.customer}\nTotal: {total}\n".encode("utf-8")
-    )
-    xml_url = upload_bytes(
-        f"cfdi/{uuid}.xml", xml_content.encode("utf-8"), "application/xml"
-    )
+    xml_content = _build_xml(uuid, payload.customer, payload.items, total)
+    pdf_content = _build_pdf(uuid, payload.customer, total)
+    xml_url = upload_bytes(f"cfdi/{uuid}.xml", xml_content, "application/xml")
     pdf_url = upload_bytes(f"cfdi/{uuid}.pdf", pdf_content, "application/pdf")
+
+    row = CfdiDocumentORM(
+        uuid=uuid,
+        customer=payload.customer,
+        total=total,
+        xml_url=xml_url,
+        pdf_url=pdf_url,
+    )
+    db.add(row)
+    db.commit()
+
     return CfdiResponse(uuid=uuid, xml_url=xml_url, pdf_url=pdf_url)
+
+
+@router.get("/{cfdi_uuid}")
+def download_cfdi(
+    cfdi_uuid: str,
+    file: str = Query("xml", pattern="^(xml|pdf)$"),
+    db: Session = Depends(get_db),
+    claims: dict = Depends(require_roles(["admin"])),
+):
+    row = db.query(CfdiDocumentORM).filter(CfdiDocumentORM.uuid == cfdi_uuid).first()
+    if not row:
+        raise HTTPException(status_code=404, detail="cfdi_not_found")
+    url = row.xml_url if file == "xml" else row.pdf_url
+    media_type = "application/xml" if file == "xml" else "application/pdf"
+    filename = f"{cfdi_uuid}.{file}"
+    return _serve_url(url, filename, media_type)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -77,3 +77,16 @@ class InvoiceORM(Base):
     created_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True, default=lambda: datetime.now(timezone.utc)
     )
+
+
+class CfdiDocumentORM(Base):
+    __tablename__ = "cfdi_documents"
+
+    uuid: Mapped[str] = mapped_column(String(32), primary_key=True)
+    customer: Mapped[str] = mapped_column(String(255), nullable=False)
+    total: Mapped[float] = mapped_column(Float, nullable=False)
+    xml_url: Mapped[str] = mapped_column(String(1024), nullable=False)
+    pdf_url: Mapped[str] = mapped_column(String(1024), nullable=False)
+    created_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True, default=lambda: datetime.now(timezone.utc)
+    )

--- a/backend/tests/test_cfdi.py
+++ b/backend/tests/test_cfdi.py
@@ -31,3 +31,14 @@ def test_generate_cfdi(tmp_path, monkeypatch):
     assert data["status"] == "generated"
     assert data["xml_url"].startswith("file://")
     assert data["pdf_url"].startswith("file://")
+
+    cfdi_uuid = data["uuid"]
+    resp_xml = client.get(f"/cfdi/{cfdi_uuid}?file=xml", headers=headers)
+    assert resp_xml.status_code == 200
+    assert resp_xml.headers["content-type"] == "application/xml"
+    assert b"<?xml" in resp_xml.content
+
+    resp_pdf = client.get(f"/cfdi/{cfdi_uuid}?file=pdf", headers=headers)
+    assert resp_pdf.status_code == 200
+    assert resp_pdf.headers["content-type"] == "application/pdf"
+    assert resp_pdf.content.startswith(b"%PDF")


### PR DESCRIPTION
## Summary
- simulate CFDI sealing and stamping into XML and simple PDF
- persist CFDI document metadata to new cfdi_documents table
- allow downloading stored CFDIs and add tests for retrieval

## Testing
- `pytest backend/tests/test_cfdi.py`

------
https://chatgpt.com/codex/tasks/task_e_68a5db88c87c83339c6622bd8ea43249