### PR TITLE
feat: add background sync queue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "concurrently": "^9.0.1",
         "eslint": "^9",
         "eslint-config-next": "15.4.6",
+        "fake-indexeddb": "^6.1.0",
         "jsdom": "^23.0.0",
         "tailwindcss": "^4",
         "typescript": "^5",
@@ -5664,6 +5665,16 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.1.0.tgz",
+      "integrity": "sha512-gOzajWIhEug/CQHUIxigKT9Zilh5/I6WvUBez6/UdUtT/YVEHM9r572Os8wfvhp7TkmgBtRNdqSM7YoCXWMzZg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fast-deep-equal": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.539.0",
     "next": "15.4.6",
+    "next-auth": "^4.24.7",
     "qrcode.react": "^4.2.0",
     "react": "19.1.0",
     "react-dom": "19.1.0",
@@ -32,23 +33,23 @@
     "recharts": "^3.1.2",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1",
-    "tailwindcss-animate": "^1.0.7",
-    "next-auth": "^4.24.7"
+    "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
+    "@testing-library/jest-dom": "^6.0.0",
+    "@testing-library/react": "^16.0.0",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "concurrently": "^9.0.1",
     "eslint": "^9",
     "eslint-config-next": "15.4.6",
+    "fake-indexeddb": "^6.1.0",
+    "jsdom": "^23.0.0",
     "tailwindcss": "^4",
     "typescript": "^5",
-    "vitest": "^1.0.0",
-    "@testing-library/react": "^16.0.0",
-    "@testing-library/jest-dom": "^6.0.0",
-    "jsdom": "^23.0.0"
+    "vitest": "^1.0.0"
   }
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,13 +1,16 @@
-const DB_NAME = 'nexora-db';
-const STORE_NAME = 'operations';
+// Service worker queue with IndexedDB and exponential backoff
 
-function openDB() {
+const DB_NAME = 'nexora-db';
+const STORE_NAME = 'queue';
+const MAX_RETRIES = 5;
+
+export function openDB() {
   return new Promise((resolve, reject) => {
     const request = indexedDB.open(DB_NAME, 1);
     request.onupgradeneeded = () => {
       const db = request.result;
       if (!db.objectStoreNames.contains(STORE_NAME)) {
-        db.createObjectStore(STORE_NAME, { autoIncrement: true });
+        db.createObjectStore(STORE_NAME, { keyPath: 'id', autoIncrement: true });
       }
     };
     request.onsuccess = () => resolve(request.result);
@@ -15,7 +18,7 @@ function openDB() {
   });
 }
 
-async function readAll(db) {
+export async function readAll(db) {
   const tx = db.transaction(STORE_NAME, 'readonly');
   const req = tx.objectStore(STORE_NAME).getAll();
   return new Promise((resolve, reject) => {
@@ -24,32 +27,67 @@ async function readAll(db) {
   });
 }
 
-async function clearStore(db) {
+export async function updateRetry(db, id, retry) {
   const tx = db.transaction(STORE_NAME, 'readwrite');
-  tx.objectStore(STORE_NAME).clear();
+  const store = tx.objectStore(STORE_NAME);
+  const itemReq = store.get(id);
+  const item = await new Promise((resolve, reject) => {
+    itemReq.onsuccess = () => resolve(itemReq.result);
+    itemReq.onerror = () => reject(itemReq.error);
+  });
+  if (item) {
+    item.retry = retry;
+    store.put(item);
+  }
   return new Promise((resolve, reject) => {
     tx.oncomplete = () => resolve();
     tx.onerror = () => reject(tx.error);
   });
 }
 
-self.addEventListener('sync', event => {
-  if (event.tag === 'sync-operations') {
-    event.waitUntil((async () => {
-      const db = await openDB();
-      const ops = await readAll(db);
-      for (const op of ops) {
-        try {
-          await fetch('/api/operations', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(op)
-          });
-        } catch (err) {
-          return; // leave for next sync
-        }
+export async function remove(db, id) {
+  const tx = db.transaction(STORE_NAME, 'readwrite');
+  tx.objectStore(STORE_NAME).delete(id);
+  return new Promise((resolve, reject) => {
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+export async function processQueue(type) {
+  const db = await openDB();
+  const all = await readAll(db);
+  const items = all.filter(item => item.type === type);
+
+  for (const item of items) {
+    let attempt = item.retry || 0;
+    try {
+      const res = await fetch(`/api/${type}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(item.payload)
+      });
+      if (!res.ok) throw new Error('Bad response');
+      await remove(db, item.id);
+    } catch (err) {
+      attempt += 1;
+      if (attempt < MAX_RETRIES) {
+        await updateRetry(db, item.id, attempt);
+        const backoff = Math.min(1000 * 2 ** (attempt - 1), 60000);
+        setTimeout(() => {
+          self.registration?.sync?.register(`sync-${type}`);
+        }, backoff);
+      } else {
+        await remove(db, item.id);
       }
-      await clearStore(db);
-    })());
+    }
+  }
+}
+
+self.addEventListener('sync', event => {
+  if (event.tag && event.tag.startsWith('sync-')) {
+    const type = event.tag.replace('sync-', '');
+    event.waitUntil(processQueue(type));
   }
 });
+

--- a/src/__tests__/background-sync.test.ts
+++ b/src/__tests__/background-sync.test.ts
@@ -1,0 +1,48 @@
+import 'fake-indexeddb/auto';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { enqueueOperation, getQueue, clearQueue } from '@/lib/db';
+import { processQueue } from '../../public/sw.js';
+
+describe('background sync queue', () => {
+  beforeEach(async () => {
+    await clearQueue();
+    // stub service worker registration for retries
+    (globalThis as any).self = {
+      registration: { sync: { register: vi.fn(() => Promise.resolve()) } }
+    };
+  });
+
+  it('persists operations when offline', async () => {
+    await enqueueOperation('cotizaciones', { id: 1 });
+    const items = await getQueue('cotizaciones');
+    expect(items).toHaveLength(1);
+    expect(items[0].payload).toEqual({ id: 1 });
+  });
+
+  it('resends and clears queue on success', async () => {
+    await enqueueOperation('cotizaciones', { id: 2 });
+    global.fetch = vi.fn(() => Promise.resolve(new Response(null, { status: 200 })));
+    await processQueue('cotizaciones');
+    const items = await getQueue('cotizaciones');
+    expect(items).toHaveLength(0);
+  });
+
+  it('retries failed operations', async () => {
+    await enqueueOperation('cotizaciones', { id: 3 });
+    let attempt = 0;
+    global.fetch = vi.fn(() => {
+      attempt += 1;
+      if (attempt === 1) return Promise.reject(new Error('offline'));
+      return Promise.resolve(new Response(null, { status: 200 }));
+    });
+
+    await processQueue('cotizaciones');
+    let items = await getQueue('cotizaciones');
+    expect(items[0].retry).toBe(1);
+
+    await processQueue('cotizaciones');
+    items = await getQueue('cotizaciones');
+    expect(items).toHaveLength(0);
+  });
+});
+

--- a/src/app/service-worker.tsx
+++ b/src/app/service-worker.tsx
@@ -5,7 +5,14 @@ import { useEffect } from 'react';
 export function ServiceWorker() {
   useEffect(() => {
     if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.register('/sw.js').catch(() => {});
+      navigator.serviceWorker
+        .register('/sw.js', { type: 'module' })
+        .then(registration => {
+          ['cotizaciones', 'evidencias'].forEach(tag => {
+            registration.sync?.register(`sync-${tag}`).catch(() => {});
+          });
+        })
+        .catch(() => {});
     }
   }, []);
   return null;


### PR DESCRIPTION
## Summary
- implement IndexedDB queue with exponential backoff in service worker
- register background sync for quotes and evidence operations
- provide DB utilities and tests for queue persistence and retry

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5de6526148333b8b22e29030f33c4