### PR TITLE
feat: add billing subscriptions

### DIFF
--- a/backend/alembic/versions/20250818_0006_add_subscriptions.py
+++ b/backend/alembic/versions/20250818_0006_add_subscriptions.py
@@ -1,0 +1,34 @@
+"""add subscriptions table
+
+Revision ID: 20250818_0006
+Revises: 20250818_0005
+Create Date: 2025-08-20 00:00:00.000000
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '20250818_0006'
+down_revision = '20250818_0005'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'subscriptions',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('customer_id', sa.String(length=64), nullable=False),
+        sa.Column('plan_id', sa.String(length=64), nullable=False),
+        sa.Column('provider', sa.String(length=32), nullable=False),
+        sa.Column('provider_subscription_id', sa.String(length=255), nullable=False),
+        sa.Column('status', sa.String(length=32), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('provider_subscription_id'),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('subscriptions')

--- a/backend/app/billing.py
+++ b/backend/app/billing.py
@@ -1,9 +1,12 @@
-from fastapi import APIRouter, Request, Depends
+import os
+from fastapi import APIRouter, Request, Depends, HTTPException
 from pydantic import BaseModel
 from typing import Literal
+from sqlalchemy.orm import Session
 
 from .auth import require_roles
-
+from .db import get_db
+from .models import SubscriptionORM
 
 router = APIRouter(prefix="/portal/api/billing", tags=["billing"])
 
@@ -20,35 +23,177 @@ class SubscriptionResponse(BaseModel):
     status: Literal["active", "cancelled"]
 
 
+class StripeProvider:
+    name = "stripe"
+
+    def __init__(self) -> None:
+        import stripe
+
+        stripe.api_key = os.getenv("STRIPE_API_KEY", "")
+        self.stripe = stripe
+        self.webhook_secret = os.getenv("STRIPE_WEBHOOK_SECRET", "")
+
+    def create_subscription(self, customer_id: str, plan_id: str) -> str:
+        sub = self.stripe.Subscription.create(
+            customer=customer_id, items=[{"price": plan_id}]
+        )
+        return sub["id"]
+
+    def cancel_subscription(self, subscription_id: str) -> None:
+        self.stripe.Subscription.delete(subscription_id)
+
+    def validate_webhook(self, payload: bytes, sig_header: str):
+        return self.stripe.Webhook.construct_event(
+            payload, sig_header, self.webhook_secret
+        )
+
+    def parse_event(self, event):
+        obj = event["data"]["object"]
+        if event["type"] == "customer.subscription.deleted":
+            status = "cancelled"
+        else:
+            status = obj.get("status", "active")
+        return obj["id"], status
+
+
+class MercadoPagoProvider:
+    name = "mercadopago"
+
+    def __init__(self) -> None:
+        import mercadopago
+
+        token = os.getenv("MERCADOPAGO_ACCESS_TOKEN", "")
+        self.sdk = mercadopago.SDK(token)
+
+    def create_subscription(self, customer_id: str, plan_id: str) -> str:
+        sub = self.sdk.subscription().create(
+            {"preapproval_plan_id": plan_id, "payer_email": customer_id}
+        )
+        return sub["response"]["id"]
+
+    def cancel_subscription(self, subscription_id: str) -> None:
+        self.sdk.subscription().cancel(subscription_id)
+
+    def validate_webhook(self, payload: bytes, sig_header: str):
+        import json
+
+        return json.loads(payload.decode())
+
+    def parse_event(self, event):
+        data = event.get("data", {}) or {}
+        status = event.get("type")
+        if status == "subscription_preapproval_cancelled":
+            status = "cancelled"
+        else:
+            status = "active"
+        return data.get("id"), status
+
+
+class PaddleProvider:
+    name = "paddle"
+
+    def __init__(self) -> None:
+        from paddle_client import PaddleClient
+
+        api_key = os.getenv("PADDLE_API_KEY", "")
+        self.client = PaddleClient(api_key=api_key)
+
+    def create_subscription(self, customer_id: str, plan_id: str) -> str:
+        sub = self.client.subscriptions.create(
+            {"plan_id": plan_id, "customer_id": customer_id}
+        )
+        return sub["id"]
+
+    def cancel_subscription(self, subscription_id: str) -> None:
+        self.client.subscriptions.cancel(subscription_id)
+
+    def validate_webhook(self, payload: bytes, sig_header: str):
+        import json
+
+        return json.loads(payload.decode())
+
+    def parse_event(self, event):
+        data = event.get("data", {}) or {}
+        return data.get("id"), data.get("status", "active")
+
+
+def get_billing_provider():
+    provider = os.getenv("BILLING_PROVIDER", "stripe").lower()
+    if provider == "stripe":
+        return StripeProvider()
+    if provider == "mercadopago":
+        return MercadoPagoProvider()
+    if provider == "paddle":
+        return PaddleProvider()
+    raise RuntimeError("Unsupported billing provider")
+
+
 @router.post("/subscribe", response_model=SubscriptionResponse)
 def subscribe(
     payload: SubscriptionRequest,
+    db: Session = Depends(get_db),
     claims: dict = Depends(require_roles(["admin"])),
 ):
-    """Crea una suscripción para el cliente indicado."""
-    return SubscriptionResponse(
+    provider = get_billing_provider()
+    ext_id = provider.create_subscription(payload.customer_id, payload.plan_id)
+    sub = SubscriptionORM(
         customer_id=payload.customer_id,
         plan_id=payload.plan_id,
+        provider=provider.name,
+        provider_subscription_id=ext_id,
         status="active",
+    )
+    db.add(sub)
+    db.commit()
+    return SubscriptionResponse(
+        customer_id=sub.customer_id, plan_id=sub.plan_id, status=sub.status
     )
 
 
 @router.post("/cancel", response_model=SubscriptionResponse)
 def cancel(
     payload: SubscriptionRequest,
+    db: Session = Depends(get_db),
     claims: dict = Depends(require_roles(["admin"])),
 ):
-    """Cancela la suscripción del cliente."""
+    sub = (
+        db.query(SubscriptionORM)
+        .filter_by(customer_id=payload.customer_id, plan_id=payload.plan_id)
+        .first()
+    )
+    if not sub:
+        raise HTTPException(status_code=404, detail="subscription_not_found")
+    provider = get_billing_provider()
+    provider.cancel_subscription(sub.provider_subscription_id)
+    sub.status = "cancelled"
+    db.commit()
     return SubscriptionResponse(
-        customer_id=payload.customer_id,
-        plan_id=payload.plan_id,
-        status="cancelled",
+        customer_id=sub.customer_id, plan_id=sub.plan_id, status=sub.status
     )
 
 
 @router.post("/webhook")
-async def webhook(request: Request):
-    """Recibe eventos de pago de Stripe o Mercado Pago."""
-    event = await request.json()
-    provider = event.get("provider")
-    return {"received": True, "provider": provider}
+async def webhook(request: Request, db: Session = Depends(get_db)):
+    provider = get_billing_provider()
+    payload = await request.body()
+    sig_header = (
+        request.headers.get("stripe-signature")
+        if provider.name == "stripe"
+        else request.headers.get("x-signature", "")
+    )
+    try:
+        event = provider.validate_webhook(payload, sig_header)
+    except Exception:
+        raise HTTPException(status_code=400, detail="invalid_signature")
+
+    sub_id, status = provider.parse_event(event)
+    if sub_id and status:
+        sub = (
+            db.query(SubscriptionORM)
+            .filter_by(provider_subscription_id=sub_id)
+            .first()
+        )
+        if sub:
+            sub.status = status
+            db.commit()
+    return {"received": True}

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -90,3 +90,17 @@ class CfdiDocumentORM(Base):
     created_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True, default=lambda: datetime.now(timezone.utc)
     )
+
+
+class SubscriptionORM(Base):
+    __tablename__ = "subscriptions"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    customer_id: Mapped[str] = mapped_column(String(64), nullable=False)
+    plan_id: Mapped[str] = mapped_column(String(64), nullable=False)
+    provider: Mapped[str] = mapped_column(String(32), nullable=False)
+    provider_subscription_id: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
+    status: Mapped[str] = mapped_column(String(32), nullable=False, default="active")
+    created_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True, default=lambda: datetime.now(timezone.utc)
+    )

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,6 +6,10 @@ python-jose[cryptography]==3.3.0
 SQLAlchemy==2.0.36
 alembic==1.13.2
 psycopg[binary]==3.2.3
+# Billing providers
+stripe==12.4.0
+mercadopago==2.3.0
+paddle-client==1.0.0
 # Testing
 pytest==8.3.3
 httpx==0.28.1

--- a/backend/tests/test_billing.py
+++ b/backend/tests/test_billing.py
@@ -1,0 +1,111 @@
+import os
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+import stripe
+from datetime import datetime, timedelta, timezone
+from jose import jwt
+
+from backend.app.main import app, engine
+from backend.app.auth import SECRET, ALGO
+
+client = TestClient(app)
+
+
+def _auth_headers():
+    now = datetime.now(timezone.utc)
+    token = jwt.encode(
+        {"sub": "tester", "roles": ["admin"], "exp": int((now + timedelta(hours=1)).timestamp())},
+        SECRET,
+        algorithm=ALGO,
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_subscribe_and_webhook(monkeypatch):
+    os.environ["BILLING_PROVIDER"] = "stripe"
+    os.environ["STRIPE_API_KEY"] = "sk_test"
+    os.environ["STRIPE_WEBHOOK_SECRET"] = "whsec_test"
+
+    monkeypatch.setattr(
+        stripe.Subscription,
+        "create",
+        staticmethod(lambda customer, items: {"id": "sub_123"}),
+    )
+    monkeypatch.setattr(
+        stripe.Subscription, "delete", staticmethod(lambda id: {"id": id})
+    )
+
+    payload = {"customer_id": "cus_123", "plan_id": "plan_basic"}
+    r = client.post(
+        "/portal/api/billing/subscribe", json=payload, headers=_auth_headers()
+    )
+    assert r.status_code == 200
+    assert r.json()["status"] == "active"
+
+    with engine.begin() as conn:
+        row = conn.execute(
+            text(
+                "SELECT status, provider_subscription_id FROM subscriptions WHERE customer_id='cus_123'"
+            )
+        ).first()
+        assert row is not None
+        assert row.status == "active"
+        sub_id = row.provider_subscription_id
+
+    def fake_construct_event(payload, sig, secret):
+        return {
+            "type": "customer.subscription.deleted",
+            "data": {"object": {"id": sub_id}},
+        }
+
+    monkeypatch.setattr(
+        stripe.Webhook, "construct_event", staticmethod(fake_construct_event)
+    )
+
+    r2 = client.post(
+        "/portal/api/billing/webhook",
+        headers={"stripe-signature": "t"},
+        content=b"{}",
+    )
+    assert r2.status_code == 200
+
+    with engine.begin() as conn:
+        row2 = conn.execute(
+            text(
+                "SELECT status FROM subscriptions WHERE provider_subscription_id=:id"
+            ),
+            {"id": sub_id},
+        ).first()
+        assert row2.status == "cancelled"
+
+
+def test_cancel_endpoint(monkeypatch):
+    os.environ["BILLING_PROVIDER"] = "stripe"
+    os.environ["STRIPE_API_KEY"] = "sk_test"
+
+    monkeypatch.setattr(
+        stripe.Subscription,
+        "create",
+        staticmethod(lambda customer, items: {"id": "sub_cancel"}),
+    )
+    payload = {"customer_id": "cus_cancel", "plan_id": "plan_basic"}
+    client.post(
+        "/portal/api/billing/subscribe", json=payload, headers=_auth_headers()
+    )
+
+    monkeypatch.setattr(
+        stripe.Subscription, "delete", staticmethod(lambda id: {"id": id})
+    )
+    r = client.post(
+        "/portal/api/billing/cancel", json=payload, headers=_auth_headers()
+    )
+    assert r.status_code == 200
+    assert r.json()["status"] == "cancelled"
+
+    with engine.begin() as conn:
+        row = conn.execute(
+            text(
+                "SELECT status FROM subscriptions WHERE customer_id='cus_cancel'"
+            )
+        ).first()
+        assert row.status == "cancelled"


### PR DESCRIPTION
## Summary
- integrate Stripe, MercadoPago and Paddle billing providers with dynamic selection
- add subscriptions table and migration
- handle billing webhooks and provide subscribe/cancel endpoints with tests

## Testing
- `pytest backend/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5ea1b157c833393d762f4ac66d6c6