### PR TITLE
feat: add admin-protected stock and invoice routers

### DIFF
--- a/backend/app/invoice.py
+++ b/backend/app/invoice.py
@@ -1,0 +1,99 @@
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from pydantic import BaseModel
+
+from .db import get_db
+from .models import InvoiceORM
+from .auth import require_roles
+
+router = APIRouter(prefix="/invoices", tags=["invoices"])
+
+
+class InvoiceCreate(BaseModel):
+    customer: str
+    total: float
+
+
+class InvoiceUpdate(BaseModel):
+    customer: str | None = None
+    total: float | None = None
+
+
+class Invoice(BaseModel):
+    id: int
+    customer: str
+    total: float
+    created_at: datetime | None = None
+
+
+@router.get("/", response_model=list[Invoice])
+def list_invoices(
+    db: Session = Depends(get_db),
+    claims: dict = Depends(require_roles(["admin"])),
+):
+    rows = db.query(InvoiceORM).all()
+    return [
+        Invoice(id=r.id, customer=r.customer, total=r.total, created_at=r.created_at)
+        for r in rows
+    ]
+
+
+@router.post("/", response_model=Invoice)
+def create_invoice(
+    payload: InvoiceCreate,
+    db: Session = Depends(get_db),
+    claims: dict = Depends(require_roles(["admin"])),
+):
+    row = InvoiceORM(customer=payload.customer, total=payload.total)
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return Invoice(id=row.id, customer=row.customer, total=row.total, created_at=row.created_at)
+
+
+@router.get("/{invoice_id}", response_model=Invoice)
+def get_invoice(
+    invoice_id: int,
+    db: Session = Depends(get_db),
+    claims: dict = Depends(require_roles(["admin"])),
+):
+    row = db.get(InvoiceORM, invoice_id)
+    if not row:
+        raise HTTPException(status_code=404, detail="invoice_not_found")
+    return Invoice(id=row.id, customer=row.customer, total=row.total, created_at=row.created_at)
+
+
+@router.put("/{invoice_id}", response_model=Invoice)
+def update_invoice(
+    invoice_id: int,
+    payload: InvoiceUpdate,
+    db: Session = Depends(get_db),
+    claims: dict = Depends(require_roles(["admin"])),
+):
+    row = db.get(InvoiceORM, invoice_id)
+    if not row:
+        raise HTTPException(status_code=404, detail="invoice_not_found")
+    if payload.customer is not None:
+        row.customer = payload.customer
+    if payload.total is not None:
+        row.total = payload.total
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return Invoice(id=row.id, customer=row.customer, total=row.total, created_at=row.created_at)
+
+
+@router.delete("/{invoice_id}", response_model=dict)
+def delete_invoice(
+    invoice_id: int,
+    db: Session = Depends(get_db),
+    claims: dict = Depends(require_roles(["admin"])),
+):
+    row = db.get(InvoiceORM, invoice_id)
+    if not row:
+        raise HTTPException(status_code=404, detail="invoice_not_found")
+    db.delete(row)
+    db.commit()
+    return {"deleted": True}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,6 +13,8 @@ from . import auth as auth_router
 from . import quotes as quotes_router
 from . import cfdi as cfdi_router
 from . import billing as billing_router
+from . import stock as stock_router
+from . import invoice as invoice_router
 from .db import Base, engine, DATABASE_URL
 
 
@@ -80,3 +82,5 @@ app.include_router(auth_router.router)
 app.include_router(quotes_router.router)
 app.include_router(cfdi_router.router)
 app.include_router(billing_router.router)
+app.include_router(stock_router.router)
+app.include_router(invoice_router.router)

--- a/backend/app/stock.py
+++ b/backend/app/stock.py
@@ -1,0 +1,89 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from pydantic import BaseModel
+
+from .db import get_db
+from .models import StockORM
+from .auth import require_roles
+
+router = APIRouter(prefix="/stock", tags=["stock"])
+
+
+class StockCreate(BaseModel):
+    item: str
+    quantity: int
+    unit_price: float
+
+
+class StockUpdate(BaseModel):
+    item: str | None = None
+    quantity: int | None = None
+    unit_price: float | None = None
+
+
+class StockItem(BaseModel):
+    id: int
+    item: str
+    quantity: int
+    unit_price: float
+
+
+@router.get("/", response_model=list[StockItem])
+def list_stock(
+    db: Session = Depends(get_db),
+    claims: dict = Depends(require_roles(["admin"])),
+):
+    rows = db.query(StockORM).all()
+    return [
+        StockItem(id=r.id, item=r.item, quantity=r.quantity, unit_price=r.unit_price)
+        for r in rows
+    ]
+
+
+@router.post("/", response_model=StockItem)
+def create_stock(
+    payload: StockCreate,
+    db: Session = Depends(get_db),
+    claims: dict = Depends(require_roles(["admin"])),
+):
+    row = StockORM(item=payload.item, quantity=payload.quantity, unit_price=payload.unit_price)
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return StockItem(id=row.id, item=row.item, quantity=row.quantity, unit_price=row.unit_price)
+
+
+@router.put("/{stock_id}", response_model=StockItem)
+def update_stock(
+    stock_id: int,
+    payload: StockUpdate,
+    db: Session = Depends(get_db),
+    claims: dict = Depends(require_roles(["admin"])),
+):
+    row = db.get(StockORM, stock_id)
+    if not row:
+        raise HTTPException(status_code=404, detail="stock_not_found")
+    if payload.item is not None:
+        row.item = payload.item
+    if payload.quantity is not None:
+        row.quantity = payload.quantity
+    if payload.unit_price is not None:
+        row.unit_price = payload.unit_price
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return StockItem(id=row.id, item=row.item, quantity=row.quantity, unit_price=row.unit_price)
+
+
+@router.delete("/{stock_id}", response_model=dict)
+def delete_stock(
+    stock_id: int,
+    db: Session = Depends(get_db),
+    claims: dict = Depends(require_roles(["admin"])),
+):
+    row = db.get(StockORM, stock_id)
+    if not row:
+        raise HTTPException(status_code=404, detail="stock_not_found")
+    db.delete(row)
+    db.commit()
+    return {"deleted": True}

--- a/backend/tests/test_stock_invoice.py
+++ b/backend/tests/test_stock_invoice.py
@@ -1,19 +1,67 @@
-from backend.app.db import SessionLocal
-from backend.app.models import StockORM, InvoiceORM
+from datetime import datetime, timedelta, timezone
 
+from fastapi.testclient import TestClient
+from jose import jwt
 
-def test_stock_and_invoice_insert_and_query():
-    db = SessionLocal()
-    try:
-        stock = StockORM(item="Widget", quantity=5, unit_price=2.0)
-        invoice = InvoiceORM(customer="ACME", total=10.0)
-        db.add_all([stock, invoice])
-        db.commit()
-        db.refresh(stock)
-        db.refresh(invoice)
-        s = db.get(StockORM, stock.id)
-        i = db.get(InvoiceORM, invoice.id)
-        assert s is not None and s.item == "Widget"
-        assert i is not None and i.customer == "ACME" and i.total == 10.0
-    finally:
-        db.close()
+from backend.app.main import app
+from backend.app.auth import SECRET, ALGO
+
+client = TestClient(app)
+
+def make_token(roles):
+    now = datetime.now(timezone.utc)
+    return jwt.encode(
+        {"sub": "tester", "roles": roles, "exp": int((now + timedelta(hours=1)).timestamp())},
+        SECRET,
+        algorithm=ALGO,
+    )
+
+def test_stock_crud_and_permissions():
+    token_admin = make_token(["admin"])
+    token_user = make_token(["user"])
+
+    payload = {"item": "Widget", "quantity": 5, "unit_price": 2.0}
+    r = client.post("/stock/", json=payload, headers={"Authorization": f"Bearer {token_admin}"})
+    assert r.status_code == 200, r.text
+    data = r.json()
+    assert data["item"] == "Widget"
+
+    r_list = client.get("/stock/", headers={"Authorization": f"Bearer {token_admin}"})
+    assert r_list.status_code == 200
+    items = r_list.json()
+    assert any(it["id"] == data["id"] for it in items)
+
+    r_forbidden = client.post(
+        "/stock/",
+        json={"item": "X", "quantity": 1, "unit_price": 1.0},
+        headers={"Authorization": f"Bearer {token_user}"},
+    )
+    assert r_forbidden.status_code == 403
+
+    r_list_forbidden = client.get("/stock/", headers={"Authorization": f"Bearer {token_user}"})
+    assert r_list_forbidden.status_code == 403
+
+def test_invoice_crud_and_permissions():
+    token_admin = make_token(["admin"])
+    token_user = make_token(["user"])
+
+    payload = {"customer": "ACME", "total": 10.0}
+    r = client.post("/invoices/", json=payload, headers={"Authorization": f"Bearer {token_admin}"})
+    assert r.status_code == 200, r.text
+    data = r.json()
+    assert data["customer"] == "ACME"
+
+    r_list = client.get("/invoices/", headers={"Authorization": f"Bearer {token_admin}"})
+    assert r_list.status_code == 200
+    items = r_list.json()
+    assert any(it["id"] == data["id"] for it in items)
+
+    r_forbidden = client.post(
+        "/invoices/",
+        json={"customer": "Nope", "total": 1.0},
+        headers={"Authorization": f"Bearer {token_user}"},
+    )
+    assert r_forbidden.status_code == 403
+
+    r_list_forbidden = client.get("/invoices/", headers={"Authorization": f"Bearer {token_user}"})
+    assert r_list_forbidden.status_code == 403


### PR DESCRIPTION
## Summary
- add stock and invoice CRUD routers guarded by admin role
- register new routers in main app
- test creation, listing and permissions

## Testing
- `ruff check backend/app/stock.py backend/app/invoice.py backend/app/main.py backend/tests/test_stock_invoice.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a60ec65a6483339b8574e1578a65de