### PR TITLE
feat(cfdi): add async stamping queue

### DIFF
--- a/backend/alembic/versions/20250818_0007_add_tax_config_and_cfdi_pending.py
+++ b/backend/alembic/versions/20250818_0007_add_tax_config_and_cfdi_pending.py
@@ -1,0 +1,33 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = '20250818_0007'
+down_revision = '20250818_0006'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'tax_config',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('rfc', sa.String(length=64), nullable=False),
+        sa.Column('provider', sa.String(length=64), nullable=True),
+        sa.Column('updated_at', sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_table(
+        'cfdi_pending',
+        sa.Column('id', sa.String(length=32), primary_key=True),
+        sa.Column('quote_id', sa.String(length=32), nullable=False),
+        sa.Column('customer', sa.String(length=255), nullable=False),
+        sa.Column('total', sa.Float(), nullable=False),
+        sa.Column('status', sa.String(length=16), nullable=False, server_default='pending'),
+        sa.Column('attempts', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('last_error', sa.String(length=255), nullable=True),
+        sa.Column('updated_at', sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_table('cfdi_pending')
+    op.drop_table('tax_config')

--- a/backend/app/cfdi_queue.py
+++ b/backend/app/cfdi_queue.py
@@ -1,0 +1,113 @@
+import json
+import os
+import logging
+import time
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from sqlalchemy.orm import Session
+
+from .models import CfdiPendingORM, CfdiDocumentORM
+from .storage import upload_bytes
+from .cfdi import _build_xml, _build_pdf, Item
+
+logger = logging.getLogger(__name__)
+
+try:
+    import redis
+except Exception:  # pragma: no cover
+    redis = None
+
+try:
+    import fakeredis
+except Exception:  # pragma: no cover
+    fakeredis = None
+
+_local_queue: list[str] = []
+
+
+def _get_redis():
+    url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+    if redis is not None:
+        try:
+            client = redis.from_url(url)
+            client.ping()
+            return client
+        except Exception as exc:  # pragma: no cover
+            logger.warning("redis unavailable: %s", exc)
+    if fakeredis is not None:
+        return fakeredis.FakeStrictRedis()
+    return None
+
+
+redis_client = _get_redis()
+
+
+def _enqueue(job: dict):
+    data = json.dumps(job)
+    if redis_client is not None:
+        redis_client.rpush("cfdi_queue", data)
+    else:
+        _local_queue.append(data)
+
+
+def _dequeue():
+    if redis_client is not None:
+        item = redis_client.lpop("cfdi_queue")
+        if item:
+            if isinstance(item, bytes):
+                item = item.decode()
+            return json.loads(item)
+    else:
+        if _local_queue:
+            data = _local_queue.pop(0)
+            return json.loads(data)
+    return None
+
+
+def enqueue_cfdi_draft(db: Session, quote_id: str, customer: str, total: float) -> str:
+    row = CfdiPendingORM(quote_id=quote_id, customer=customer, total=total)
+    db.add(row)
+    db.commit()
+    _enqueue({"pending_id": row.id})
+    return row.id
+
+
+def process_cfdi_queue(db: Session, limit: int = 10) -> int:
+    processed = 0
+    for _ in range(limit):
+        job = _dequeue()
+        if not job:
+            break
+        pending = db.get(CfdiPendingORM, job["pending_id"])
+        if not pending or pending.status != "pending":
+            continue
+        pending.attempts += 1
+        pending.updated_at = datetime.now(timezone.utc)
+        try:
+            uuid = uuid4().hex
+            item = Item(description="Servicio", quantity=1, unit_price=pending.total)
+            xml_content = _build_xml(uuid, pending.customer, [item], pending.total)
+            pdf_content = _build_pdf(uuid, pending.customer, pending.total)
+            xml_url = upload_bytes(f"cfdi/{uuid}.xml", xml_content, "application/xml")
+            pdf_url = upload_bytes(f"cfdi/{uuid}.pdf", pdf_content, "application/pdf")
+            doc = CfdiDocumentORM(
+                uuid=uuid,
+                customer=pending.customer,
+                total=pending.total,
+                xml_url=xml_url,
+                pdf_url=pdf_url,
+            )
+            db.add(doc)
+            pending.status = "sent"
+            db.add(pending)
+            db.commit()
+            processed += 1
+        except Exception as exc:  # pragma: no cover
+            pending.last_error = str(exc)
+            db.add(pending)
+            db.commit()
+            delay = min(60, 2 ** pending.attempts)
+            time.sleep(delay)
+            _enqueue(job)
+    return processed

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -92,6 +92,32 @@ class CfdiDocumentORM(Base):
     )
 
 
+class CfdiPendingORM(Base):
+    __tablename__ = "cfdi_pending"
+
+    id: Mapped[str] = mapped_column(String(32), primary_key=True, default=lambda: uuid4().hex)
+    quote_id: Mapped[str] = mapped_column(String(32), nullable=False)
+    customer: Mapped[str] = mapped_column(String(255), nullable=False)
+    total: Mapped[float] = mapped_column(Float, nullable=False)
+    status: Mapped[str] = mapped_column(String(16), nullable=False, default="pending")
+    attempts: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    last_error: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    updated_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True, default=lambda: datetime.now(timezone.utc)
+    )
+
+
+class TaxConfigORM(Base):
+    __tablename__ = "tax_config"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    rfc: Mapped[str] = mapped_column(String(64), nullable=False)
+    provider: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    updated_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True, default=lambda: datetime.now(timezone.utc)
+    )
+
+
 class SubscriptionORM(Base):
     __tablename__ = "subscriptions"
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -17,3 +17,5 @@ pytest==8.3.3
 httpx==0.28.1
 boto3==1.35.57
 bcrypt==4.0.1
+redis==5.0.4
+fakeredis==2.23.2

--- a/backend/tests/test_cfdi_async.py
+++ b/backend/tests/test_cfdi_async.py
@@ -1,0 +1,54 @@
+from datetime import datetime, timedelta, timezone
+
+from fastapi.testclient import TestClient
+from jose import jwt
+
+from backend.app.main import app
+from backend.app.auth import SECRET, ALGO
+from backend.app.db import SessionLocal
+from backend.app.models import CfdiPendingORM, CfdiDocumentORM
+import backend.app.cfdi_queue as cfdi_queue
+
+
+def _auth_headers():
+    now = datetime.now(timezone.utc)
+    token = jwt.encode(
+        {"sub": "tester", "roles": ["admin"], "exp": int((now + timedelta(hours=1)).timestamp())},
+        SECRET,
+        algorithm=ALGO,
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_quote_approval_enqueue_and_process(tmp_path, monkeypatch):
+    monkeypatch.setenv("S3_ENDPOINT", "")
+    monkeypatch.setenv("S3_LOCAL_DIR", str(tmp_path))
+    monkeypatch.setenv("REDIS_URL", "")
+    cfdi_queue.redis_client = cfdi_queue._get_redis()
+    cfdi_queue._local_queue.clear()
+
+    client = TestClient(app)
+    headers = _auth_headers()
+    # create quote
+    r = client.post("/quotes/", json={"customer": "ACME", "total": 50}, headers=headers)
+    assert r.status_code == 200
+    q = r.json()
+    # approve quote triggers enqueue
+    r2 = client.post(f"/quotes/{q['id']}/approve", headers=headers)
+    assert r2.status_code == 200
+
+    with SessionLocal() as db:
+        pending = db.query(CfdiPendingORM).filter(CfdiPendingORM.quote_id == q["id"]).first()
+        assert pending is not None
+        assert pending.status == "pending"
+
+    # process pending cfdi
+    r3 = client.post("/cfdi/process-pending", headers=headers)
+    assert r3.status_code == 200
+    assert r3.json()["processed"] >= 1
+
+    with SessionLocal() as db:
+        pending2 = db.query(CfdiPendingORM).filter(CfdiPendingORM.quote_id == q["id"]).first()
+        assert pending2.status == "sent"
+        doc = db.query(CfdiDocumentORM).filter(CfdiDocumentORM.customer == "ACME").first()
+        assert doc is not None

--- a/docs/CFDI_SANDBOX.md
+++ b/docs/CFDI_SANDBOX.md
@@ -12,19 +12,16 @@ PAC_USER=demo
 PAC_PASS=demo
 ```
 
-## Flujo (propuesto)
+## Flujo
 
-1. **Config fiscal** en el Asistente (solo demo en MVP):
-    - Emisor (RFC, régimen, nombre, CP).
-    - Receptor (RFC genérico si procede: p. ej. público en general).
-    - Uso CFDI, método, forma de pago (demo).
-2. **Generar comprobante** desde cotización aprobada (servidor local):
-    - Construir JSON del CFDI 4.0 con partidas (claveProdServ, claveUnidad, IVA 16% etc.).
-    - Guardar borrador en DB y encolar **timbrado** (cola Redis) si no hay Internet.
-3. **Timbrado sandbox** (cuando hay conexión):
-    - POST a proveedor **sandbox** → recibir **XML** timbrado (fake) + UUID simulado.
-    - Guardar **XML** (MinIO) y generar **PDF** (plantilla simple).
-4. **Reintentos**: exponenciar con jitter; marcar como `pending → sent`.
+1. **Config fiscal** (`POST /cfdi/config`)
+    - Guardar RFC y proveedor en DB.
+2. **Cotización aprobada → borrador**
+    - Al aprobar se guarda en `cfdi_pending` y se encola en Redis.
+3. **Timbrado sandbox** (`POST /cfdi/process-pending`)
+    - Procesa la cola, genera XML/PDF y crea `cfdi_documents`.
+4. **Reintentos**
+    - Backoff exponencial, estados `pending` → `sent`.
 
 ## RFCs y pruebas
 


### PR DESCRIPTION
## Summary
- store tax config and pending CFDI drafts
- queue CFDI stamping and retry with backoff
- document sandbox endpoints and workflow

## Testing
- `pytest backend/tests/test_cfdi_async.py backend/tests/test_cfdi.py backend/tests/test_quotes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a617e478308333a7a0e466707cd2d9