### PR TITLE
Queue offline POSTs and document offline behavior

### DIFF
--- a/docs/PWA_ASSETS.md
+++ b/docs/PWA_ASSETS.md
@@ -20,8 +20,15 @@
 ## Background Sync & IndexedDB
 
 - Las operaciones offline se guardan en IndexedDB (`src/lib/db.ts`).
-- El service worker (`public/sw.js`) registra `background sync` (`sync-operations`) y reintenta cuando vuelve la conexión.
+- Cada operación se etiqueta por tipo (`cotizaciones`, `evidencias`, etc.) y se registra `sync-{tipo}`.
+- El service worker (`public/sw.js`) reintenta cuando vuelve la conexión usando esas etiquetas.
 - Al completarse, la outbox se limpia automáticamente.
+
+## Modo offline
+
+- Las vistas capturan errores de red en `fetch` (POST) y encolan la operación con `enqueueOperation`.
+- Mientras no haya conexión, las acciones quedan pendientes en IndexedDB y el usuario recibe feedback local.
+- Al restablecer la red, `background sync` envía las operaciones pendientes y actualiza el estado.
 
 ## Botón "Instalar"
 

--- a/src/__tests__/offline-ui.test.tsx
+++ b/src/__tests__/offline-ui.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+import ForgotPasswordPage from '@/app/forgot-password/page';
+import ResetPasswordPage from '@/app/reset-password/[token]/page';
+import { ApproveActions } from '@/app/approve/[token]/page';
+import { vi, describe, it, beforeEach, expect } from 'vitest';
+
+vi.mock('@/lib/db', () => ({
+  enqueueOperation: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ token: 'tok' }),
+}));
+
+import { enqueueOperation } from '@/lib/db';
+
+describe('offline ui operations', () => {
+  beforeEach(() => {
+    (enqueueOperation as any).mockClear();
+    global.fetch = vi.fn().mockRejectedValue(new Error('offline')) as any;
+  });
+
+  it('queues forgot password on network error', async () => {
+    render(<ForgotPasswordPage />);
+    fireEvent.change(screen.getByPlaceholderText(/email/i), { target: { value: 'a@b.com' } });
+    fireEvent.submit(screen.getByRole('button', { name: /enviar/i }).closest('form')!);
+    await waitFor(() => {
+      expect(enqueueOperation).toHaveBeenCalledWith('auth/forgot-password', { email: 'a@b.com' });
+    });
+  });
+
+  it('queues reset password on network error', async () => {
+    render(<ResetPasswordPage />);
+    fireEvent.change(screen.getByPlaceholderText(/nueva contraseña/i), { target: { value: '123456' } });
+    fireEvent.submit(screen.getByRole('button', { name: /restablecer/i }).closest('form')!);
+    await waitFor(() => {
+      expect(enqueueOperation).toHaveBeenCalledWith('auth/reset-password', { token: 'tok', password: '123456' });
+    });
+  });
+
+  it('queues approve confirm on network error', async () => {
+    render(<ApproveActions token="tok" quoteId="q1" />);
+    fireEvent.click(screen.getByRole('button', { name: /aprobar cotización/i }));
+    await waitFor(() => {
+      expect(enqueueOperation).toHaveBeenCalledWith('approve/confirm', { token: 'tok' });
+    });
+  });
+});

--- a/src/app/approve/[token]/page.tsx
+++ b/src/app/approve/[token]/page.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { enqueueOperation } from '@/lib/db'
 
 async function approveCheck(token: string) {
   const base = process.env.NEXT_PUBLIC_BASE_PATH || ''
@@ -10,7 +11,7 @@ async function approveCheck(token: string) {
   return { ok: res.ok, data }
 }
 
-function ApproveActions({ token, quoteId }: { token: string; quoteId: string }) {
+export function ApproveActions({ token, quoteId }: { token: string; quoteId: string }) {
   'use client'
   const [busy, setBusy] = React.useState(false)
   const [msg, setMsg] = React.useState<string | null>(null)
@@ -52,6 +53,7 @@ function ApproveActions({ token, quoteId }: { token: string; quoteId: string }) 
         setMsg('Error al aprobar. Intenta más tarde.')
       }
     } catch {
+      await enqueueOperation('approve/confirm', { token })
       setOk(false)
       setMsg('No se pudo contactar al servicio.')
     } finally {

--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
+import { enqueueOperation } from '@/lib/db'
 
 export default function ForgotPasswordPage() {
   const [email, setEmail] = useState('')
@@ -10,11 +11,15 @@ export default function ForgotPasswordPage() {
 
   async function submit(e: React.FormEvent) {
     e.preventDefault()
-    await fetch('/api/auth/forgot-password', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ email }),
-    })
+    try {
+      await fetch('/api/auth/forgot-password', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ email }),
+      })
+    } catch {
+      await enqueueOperation('auth/forgot-password', { email })
+    }
     setSent(true)
   }
 

--- a/src/app/reset-password/[token]/page.tsx
+++ b/src/app/reset-password/[token]/page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { useParams } from 'next/navigation'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
+import { enqueueOperation } from '@/lib/db'
 
 export default function ResetPasswordPage() {
   const { token } = useParams<{ token: string }>()
@@ -13,11 +14,15 @@ export default function ResetPasswordPage() {
 
   async function submit(e: React.FormEvent) {
     e.preventDefault()
-    await fetch('/api/auth/reset-password', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ token, password }),
-    })
+    try {
+      await fetch('/api/auth/reset-password', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ token, password }),
+      })
+    } catch {
+      await enqueueOperation('auth/reset-password', { token, password })
+    }
     setDone(true)
   }
 

--- a/src/app/service-worker.tsx
+++ b/src/app/service-worker.tsx
@@ -11,7 +11,13 @@ export function ServiceWorker() {
           const regWithSync = registration as unknown as {
             sync?: { register: (tag: string) => Promise<void> };
           };
-          ['cotizaciones', 'evidencias'].forEach(tag => {
+          [
+            'cotizaciones',
+            'evidencias',
+            'approve/confirm',
+            'auth/forgot-password',
+            'auth/reset-password',
+          ].forEach(tag => {
             regWithSync.sync?.register(`sync-${tag}`).catch(() => {});
           });
         })


### PR DESCRIPTION
## Summary
- capture network errors in password reset, password recovery and approval flows, enqueueing operations for background sync
- register sync tags for all operation types and document offline behavior
- cover offline queuing with tests, including UI scenarios

## Testing
- `npx vitest run src/__tests__/background-sync.test.ts src/__tests__/offline-ui.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a61f1df53883339dc18057ae030d83