### PR TITLE
feat: add JWT helpers and document NextAuth

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -51,3 +51,11 @@ La matriz de roles se define en `backend/app/auth.py` como `ROLE_MATRIX`.
 | admin | Gestión completa y operaciones críticas             |
 | user  | Operaciones estándar en la PWA                      |
 | viewer| Acceso de solo lectura a paneles e informes         |
+
+## JWT y NextAuth
+
+- El backend firma los JWT con el algoritmo indicado en `JWT_ALGO` y el secreto `JWT_SECRET`.
+- Los tokens incluyen el sujeto (`sub`), tiempo de emisión (`iat`), expiración (`exp`) y la lista de `roles` del usuario.
+- El archivo `src/app/api/auth/[...nextauth]/route.ts` configura NextAuth para usar el backend (`/auth/login` y `/auth/refresh`).
+- Los roles y el `accessToken` se almacenan en la sesión de NextAuth y se renuevan automáticamente.
+- En el frontend se consume la sesión mediante `useSession` y el helper `hasRole` para restringir vistas.

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -77,7 +77,11 @@ export const authOptions: AuthOptions = {
     async session({ session, token }) {
       const t = token as ExtendedToken
       ;(session as unknown as { accessToken?: string }).accessToken = t.accessToken
-      ;(session as unknown as { roles?: string[] }).roles = Array.isArray(t.roles) ? t.roles : undefined
+      const roles = Array.isArray(t.roles) ? t.roles : undefined
+      ;(session as unknown as { roles?: string[] }).roles = roles
+      if (session.user) {
+        ;(session.user as unknown as { roles?: string[] }).roles = roles
+      }
       return session
     },
   },


### PR DESCRIPTION
## Summary
- add helpers to generate and decode JWT with roles
- expose roles on NextAuth session user
- document JWT/NextAuth configuration

## Testing
- `npm test` (fails: runs tests from dependencies)
- `npm run backend:test`


------
https://chatgpt.com/codex/tasks/task_e_68a62b4f0710833399d695cfe41f18e1