### PR TITLE
Handle CFDI retries and expose sandbox endpoints

### DIFF
--- a/backend/tests/test_cfdi_queue_retry.py
+++ b/backend/tests/test_cfdi_queue_retry.py
@@ -1,0 +1,30 @@
+from datetime import datetime, timedelta, timezone
+
+from backend.app.db import SessionLocal
+from backend.app.models import CfdiPendingORM
+import backend.app.cfdi_queue as cfdi_queue
+
+
+def test_cfdi_queue_marks_failed_after_max_attempts(tmp_path, monkeypatch):
+    monkeypatch.setenv("S3_ENDPOINT", "")
+    monkeypatch.setenv("S3_LOCAL_DIR", str(tmp_path))
+    monkeypatch.setenv("REDIS_URL", "")
+    cfdi_queue.redis_client = cfdi_queue._get_redis()
+    cfdi_queue.MAX_ATTEMPTS = 2
+    cfdi_queue._local_queue.clear()
+
+    # enqueue a pending cfdi
+    with SessionLocal() as db:
+        pending_id = cfdi_queue.enqueue_cfdi_draft(db, "q1", "ACME", 10.0)
+
+    # force failure
+    monkeypatch.setattr(cfdi_queue, "upload_bytes", lambda *a, **k: (_ for _ in ()).throw(Exception("oops")))
+    monkeypatch.setattr(cfdi_queue, "time", type("T", (), {"sleep": lambda *_: None})())
+
+    with SessionLocal() as db:
+        cfdi_queue.process_cfdi_queue(db, limit=1)
+        pending = db.get(CfdiPendingORM, pending_id)
+        assert pending.status == "pending"
+        cfdi_queue.process_cfdi_queue(db, limit=1)
+        pending = db.get(CfdiPendingORM, pending_id)
+        assert pending.status == "failed"

--- a/src/app/api/cfdi/[uuid]/route.ts
+++ b/src/app/api/cfdi/[uuid]/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+function base() {
+  return (process.env.BACKEND_API_BASE || process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000').replace(/\/$/, '')
+}
+
+export async function GET(req: NextRequest, { params }: { params: { uuid: string } }) {
+  const file = req.nextUrl.searchParams.get('file') || 'xml'
+  try {
+    const resp = await fetch(`${base()}/cfdi/${params.uuid}?file=${file}`, { cache: 'no-store' })
+    const arrayBuffer = await resp.arrayBuffer()
+    return new NextResponse(arrayBuffer, {
+      status: resp.status,
+      headers: { 'content-type': resp.headers.get('content-type') || 'application/octet-stream' },
+    })
+  } catch (err: unknown) {
+    const detail = err instanceof Error ? err.message : String(err)
+    return NextResponse.json({ error: 'core_unreachable', detail }, { status: 502 })
+  }
+}

--- a/src/app/api/cfdi/route.ts
+++ b/src/app/api/cfdi/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+function base() {
+  return (process.env.BACKEND_API_BASE || process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000').replace(/\/$/, '')
+}
+
+export async function POST(req: NextRequest) {
+  const body = await req.json().catch(() => null)
+  if (!body) return NextResponse.json({ error: 'invalid_json' }, { status: 400 })
+  try {
+    const resp = await fetch(`${base()}/cfdi/`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', accept: 'application/json' },
+      body: JSON.stringify(body),
+      cache: 'no-store',
+    })
+    const data = await resp.json().catch(() => ({}))
+    return NextResponse.json(data, { status: resp.status })
+  } catch (err: unknown) {
+    const detail = err instanceof Error ? err.message : String(err)
+    return NextResponse.json({ error: 'core_unreachable', detail }, { status: 502 })
+  }
+}


### PR DESCRIPTION
## Summary
- handle errors during CFDI generation and downloads
- add retry limits and failure state to CFDI queue
- expose frontend API routes for CFDI generation and download
- document sandbox configuration and usage examples

## Testing
- `npm run lint` *(fails: React Hook "useState" is called conditionally)*
- `npm test` *(fails: Failed to resolve import "@internal/listenerMiddleware/utils" from redux toolkit tests)*
- `python -m pytest backend -q`

------
https://chatgpt.com/codex/tasks/task_e_68a633503d408333a61cb61bedce4dc0