### PR TITLE
feat: manage user roles and sync with UI

### DIFF
--- a/backend/tests/test_roles.py
+++ b/backend/tests/test_roles.py
@@ -1,0 +1,58 @@
+from fastapi.testclient import TestClient
+from backend.app.main import app
+from backend.app.auth import create_access_token
+from backend.app.db import SessionLocal
+from backend.app.models import UserORM
+
+client = TestClient(app)
+
+
+def test_signup_assigns_user_role_by_default():
+    r = client.post("/auth/signup", json={"email": "role1@example.com", "password": "secret"})
+    assert r.status_code == 201
+    data = r.json()
+    assert "user" in data.get("roles", [])
+    with SessionLocal() as db:
+        user = db.query(UserORM).filter_by(email="role1@example.com").one()
+        assert any(r.name == "user" for r in user.roles)
+
+
+def test_admin_can_add_and_remove_role():
+    client.post("/auth/signup", json={"email": "role2@example.com", "password": "secret"})
+    token, _ = create_access_token("admin@example.com", ["admin"])
+    headers = {"Authorization": f"Bearer {token}"}
+    add = client.post(
+        "/auth/roles",
+        json={"email": "role2@example.com", "role": "viewer"},
+        headers=headers,
+    )
+    assert add.status_code == 200
+    assert "viewer" in add.json()["roles"]
+    rem = client.request(
+        "DELETE",
+        "/auth/roles",
+        json={"email": "role2@example.com", "role": "viewer"},
+        headers=headers,
+    )
+    assert rem.status_code == 200
+    assert "viewer" not in rem.json()["roles"]
+
+
+def test_non_admin_cannot_modify_roles():
+    client.post("/auth/signup", json={"email": "role3@example.com", "password": "secret"})
+    token, _ = create_access_token("user@example.com", ["user"])
+    headers = {"Authorization": f"Bearer {token}"}
+    r = client.post(
+        "/auth/roles",
+        json={"email": "role3@example.com", "role": "viewer"},
+        headers=headers,
+    )
+    assert r.status_code == 403
+
+
+def test_get_roles_returns_current_user_roles():
+    signup = client.post("/auth/signup", json={"email": "role4@example.com", "password": "secret"})
+    token = signup.json()["access_token"]
+    resp = client.get("/auth/roles", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    assert resp.json()["roles"] == ["user"]

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -21,6 +21,16 @@ Endpoints actuales en el código, listos para pruebas E2E.
   - Body: `{ "email": string, "password": string }`
   - Resp: `{ "access_token": string, "token_type": "bearer", "exp": number, "roles": string[] }`
   - Nota: usuario demo `admin@example.com` / `admin`.
+- `POST /auth/signup`
+  - Body: `{ "email": string, "password": string, "roles?": string[] }`
+  - Resp: `{ "access_token": string, "token_type": "bearer", "exp": number, "roles": string[] }`
+  - Nota: si no se especifican roles se asigna automáticamente `user`.
+- `GET /auth/roles`
+  - Requiere token. Devuelve `{ "roles": string[] }` del usuario autenticado.
+- `POST /auth/roles`
+  - Solo admin. Body: `{ "email": string, "role": string }` → agrega rol y responde `{ "roles": string[] }`.
+- `DELETE /auth/roles`
+  - Solo admin. Body: `{ "email": string, "role": string }` → quita rol y responde `{ "roles": string[] }`.
 - `GET /quotes/` → lista de cotizaciones (in‑memory stub)
 - `POST /quotes/`
   - Body: `{ "customer": string, "total": number }`

--- a/src/__tests__/auth.test.tsx
+++ b/src/__tests__/auth.test.tsx
@@ -10,12 +10,18 @@ afterEach(() => {
 describe('nextauth auth flow', () => {
   it('refreshes token when expired', async () => {
     const jwtCb = authOptions.callbacks?.jwt as any
-    global.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({ access_token: 'new', exp: 2, roles: ['user'] }),
-    }) as any
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: 'new', exp: 2 }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ roles: ['user'] }),
+      }) as any
     const expired = Math.floor(Date.now() / 1000) - 10
-    const tok = await jwtCb({ token: { accessToken: 'old', exp: expired, roles: ['user'] } })
+    const tok = await jwtCb({ token: { accessToken: 'old', exp: expired } })
     expect(tok.accessToken).toBe('new')
     expect(tok.roles).toEqual(['user'])
   })


### PR DESCRIPTION
## Summary
- add API endpoints to list and modify user roles
- assign `user` role by default during signup
- fetch roles in NextAuth and gate UI by role
- document new auth role endpoints and add tests

## Testing
- `npx vitest run src/__tests__/approve.test.ts src/__tests__/background-sync.test.ts src/__tests__/auth.test.tsx src/__tests__/dashboard.test.tsx src/__tests__/configuracion.test.tsx src/__tests__/login.test.ts`
- `python -m pytest backend -q`

------
https://chatgpt.com/codex/tasks/task_e_68a6aacf80ec8333a6aaf159524eb210