### PR TITLE
Add sandbox CFDI queue tests and documentation

### DIFF
--- a/backend/tests/test_cfdi_async.py
+++ b/backend/tests/test_cfdi_async.py
@@ -1,4 +1,6 @@
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from urllib.parse import urlparse
 
 from fastapi.testclient import TestClient
 from jose import jwt
@@ -24,6 +26,9 @@ def test_quote_approval_enqueue_and_process(tmp_path, monkeypatch):
     monkeypatch.setenv("S3_ENDPOINT", "")
     monkeypatch.setenv("S3_LOCAL_DIR", str(tmp_path))
     monkeypatch.setenv("REDIS_URL", "")
+    monkeypatch.setenv("PAC_PROVIDER", "sandbox")
+    monkeypatch.setenv("PAC_USER", "demo")
+    monkeypatch.setenv("PAC_PASS", "demo")
     cfdi_queue.redis_client = cfdi_queue._get_redis()
     cfdi_queue._local_queue.clear()
 
@@ -52,3 +57,7 @@ def test_quote_approval_enqueue_and_process(tmp_path, monkeypatch):
         assert pending2.status == "sent"
         doc = db.query(CfdiDocumentORM).filter(CfdiDocumentORM.customer == "ACME").first()
         assert doc is not None
+        xml_path = Path(urlparse(doc.xml_url).path)
+        pdf_path = Path(urlparse(doc.pdf_url).path)
+        assert xml_path.exists()
+        assert pdf_path.exists()

--- a/backend/tests/test_cfdi_queue_retry.py
+++ b/backend/tests/test_cfdi_queue_retry.py
@@ -9,6 +9,9 @@ def test_cfdi_queue_marks_failed_after_max_attempts(tmp_path, monkeypatch):
     monkeypatch.setenv("S3_ENDPOINT", "")
     monkeypatch.setenv("S3_LOCAL_DIR", str(tmp_path))
     monkeypatch.setenv("REDIS_URL", "")
+    monkeypatch.setenv("PAC_PROVIDER", "sandbox")
+    monkeypatch.setenv("PAC_USER", "demo")
+    monkeypatch.setenv("PAC_PASS", "demo")
     cfdi_queue.redis_client = cfdi_queue._get_redis()
     cfdi_queue.MAX_ATTEMPTS = 2
     cfdi_queue._local_queue.clear()

--- a/docs/CFDI_SANDBOX.md
+++ b/docs/CFDI_SANDBOX.md
@@ -53,6 +53,30 @@ curl -L http://localhost:8000/cfdi/<UUID>?file=xml
 - Receptor **público en general** (ejemplo): `XAXX010101000`.
 - Extranjero (cuando aplique): `XEXX010101000`.
 
+## Pruebas automatizadas
+
+1. Configurar entorno de sandbox:
+
+   ```bash
+   export PAC_PROVIDER=sandbox
+   export PAC_USER=demo
+   export PAC_PASS=demo
+   export REDIS_URL=""
+   ```
+
+   Si `REDIS_URL` está vacío, se utiliza **fakeredis** para la cola.
+
+2. Ejecutar los tests:
+
+   ```bash
+   pytest backend/tests/test_cfdi_async.py backend/tests/test_cfdi_queue_retry.py
+   ```
+
+### Resultados esperados
+
+- `test_cfdi_async.py` aprueba una cotización, genera XML/PDF y cambia el estado de `pending` a `sent`.
+- `test_cfdi_queue_retry.py` fuerza errores hasta agotar `CFDI_MAX_ATTEMPTS` y marca el registro como `failed`.
+
 ## Para producción (más adelante)
 
 - Validaciones CFDI 4.0 (domicilio fiscal receptor, uso CFDI válido, etc.).


### PR DESCRIPTION
## Summary
- cover CFDI queue with sandbox environment and XML/PDF generation checks
- verify failed queue handling after max attempts
- document automated CFDI sandbox tests and expected results

## Testing
- `pytest backend/tests/test_cfdi_async.py backend/tests/test_cfdi_queue_retry.py`

------
https://chatgpt.com/codex/tasks/task_e_68a6ba1812a483339f9e9dbf0b6bc556