### PR TITLE
feat(auth): persist roles across refresh

### DIFF
--- a/backend/tests/test_rbac.py
+++ b/backend/tests/test_rbac.py
@@ -4,7 +4,7 @@ from fastapi.testclient import TestClient
 from jose import jwt
 
 from backend.app.main import app
-from backend.app.auth import SECRET, ALGO
+from backend.app.auth import SECRET, ALGO, create_access_token
 
 
 def make_token(roles):
@@ -63,5 +63,47 @@ def test_quote_approval_requires_admin():
     r_ok = client.post(
         f"/quotes/{q['id']}/approve",
         headers={"Authorization": f"Bearer {token_admin}"},
+    )
+    assert r_ok.status_code == 200
+
+
+def test_refresh_reflects_role_changes():
+    client = TestClient(app)
+    signup = client.post(
+        "/auth/signup", json={"email": "rbac@example.com", "password": "secret"}
+    )
+    assert signup.status_code == 201
+    token_user = signup.json()["access_token"]
+
+    # user cannot approve initially
+    q = client.post(
+        "/quotes/",
+        json={"customer": "RBAC", "total": 1},
+        headers={"Authorization": f"Bearer {token_user}"},
+    ).json()
+    r_forbidden = client.post(
+        f"/quotes/{q['id']}/approve",
+        headers={"Authorization": f"Bearer {token_user}"},
+    )
+    assert r_forbidden.status_code == 403
+
+    # admin grants admin role
+    admin_token, _ = create_access_token("admin@example.com", ["admin"])
+    client.post(
+        "/auth/roles",
+        json={"email": "rbac@example.com", "role": "admin"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+
+    # refresh token to pick up new role
+    refreshed = client.post(
+        "/auth/refresh", headers={"Authorization": f"Bearer {token_user}"}
+    )
+    assert refreshed.status_code == 200
+    new_token = refreshed.json()["access_token"]
+
+    r_ok = client.post(
+        f"/quotes/{q['id']}/approve",
+        headers={"Authorization": f"Bearer {new_token}"},
     )
     assert r_ok.status_code == 200

--- a/middleware.ts
+++ b/middleware.ts
@@ -5,7 +5,7 @@ export default withAuth(
   function middleware(req) {
     const roles = (req.nextauth.token?.roles as string[]) || []
     if (!roles.includes('admin')) {
-      return NextResponse.redirect(new URL('/', req.url))
+      return new NextResponse('Forbidden', { status: 403 })
     }
     return NextResponse.next()
   },

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -8,19 +8,6 @@ type ExtendedToken = JWT & { accessToken?: string; exp?: number; roles?: string[
 
 enum AuthProviderName { Credentials = 'Credentials' }
 
-async function fetchRoles(accessToken: string): Promise<string[]> {
-  const base =
-    process.env.BACKEND_API_BASE ||
-    process.env.NEXT_PUBLIC_API_BASE ||
-    'http://localhost:8000'
-  const url = `${base.replace(/\/$/, '')}/auth/roles`
-  const resp = await fetch(url, {
-    headers: { Authorization: `Bearer ${accessToken}` },
-  })
-  const data = (await resp.json().catch(() => null)) as { roles?: string[] } | null
-  return Array.isArray(data?.roles) ? (data!.roles as string[]) : []
-}
-
 export const authOptions: AuthOptions = {
   providers: [
     CredentialsProvider({
@@ -65,6 +52,7 @@ export const authOptions: AuthOptions = {
         const u = user as unknown as AppUser
         t.accessToken = u.accessToken
         t.exp = u.exp
+        t.roles = u.roles
       }
       if (t.exp && Date.now() / 1000 > t.exp - 60 && t.accessToken) {
         const base =
@@ -81,11 +69,9 @@ export const authOptions: AuthOptions = {
           if (data?.access_token) {
             t.accessToken = data.access_token
             t.exp = data.exp
+            t.roles = data.roles
           }
         }
-      }
-      if (t.accessToken) {
-        t.roles = await fetchRoles(t.accessToken)
       }
       return token
     },


### PR DESCRIPTION
## Summary
- embed roles in JWT claims and refresh from DB for up-to-date RBAC
- surface backend roles in NextAuth session and middleware
- add RBAC regression test covering role refresh

## Testing
- `pytest backend/tests/test_rbac.py -q`
- `npm test` *(fails: Failed to resolve import "@internal/listenerMiddleware/utils" in dependency tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c1ee78cc833397e4238273807ce9