### PR TITLE
Add indexes for stock and invoices

### DIFF
--- a/backend/alembic/versions/f26643d7b17d_add_stock_and_invoice_indexes.py
+++ b/backend/alembic/versions/f26643d7b17d_add_stock_and_invoice_indexes.py
@@ -1,0 +1,26 @@
+"""add stock and invoice indexes
+
+Revision ID: f26643d7b17d
+Revises: ba42116aa12c
+Create Date: 2025-08-21 07:04:51.632527
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'f26643d7b17d'
+down_revision = 'ba42116aa12c'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index('idx_stock_item', 'stock', ['item'], unique=False)
+    op.create_index('idx_invoices_customer', 'invoices', ['customer'], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index('idx_invoices_customer', table_name='invoices')
+    op.drop_index('idx_stock_item', table_name='stock')

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -121,6 +121,7 @@ class StockORM(Base):
     item: Mapped[str] = mapped_column(String(255), nullable=False)
     quantity: Mapped[int] = mapped_column(Integer, nullable=False)
     unit_price: Mapped[float] = mapped_column(Float, nullable=False)
+    __table_args__ = (Index("idx_stock_item", "item"),)
 
 
 class QuoteItemORM(Base):
@@ -194,6 +195,7 @@ class InvoiceORM(Base):
     created_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True, default=lambda: datetime.now(timezone.utc)
     )
+    __table_args__ = (Index("idx_invoices_customer", "customer"),)
 
 
 class CfdiDocumentORM(Base):

--- a/backend/tests/test_stock_invoice.py
+++ b/backend/tests/test_stock_invoice.py
@@ -21,15 +21,33 @@ def test_stock_crud_and_permissions():
     token_user = make_token(["user"])
 
     payload = {"item": "Widget", "quantity": 5, "unit_price": 2.0}
-    r = client.post("/stock/", json=payload, headers={"Authorization": f"Bearer {token_admin}"})
+    r = client.post(
+        "/stock/", json=payload, headers={"Authorization": f"Bearer {token_admin}"}
+    )
     assert r.status_code == 200, r.text
     data = r.json()
     assert data["item"] == "Widget"
 
-    r_list = client.get("/stock/", headers={"Authorization": f"Bearer {token_admin}"})
+    r_update = client.put(
+        f"/stock/{data['id']}",
+        json={"quantity": 10},
+        headers={"Authorization": f"Bearer {token_admin}"},
+    )
+    assert r_update.status_code == 200
+    assert r_update.json()["quantity"] == 10
+
+    r_list = client.get(
+        "/stock/", headers={"Authorization": f"Bearer {token_admin}"}
+    )
     assert r_list.status_code == 200
     items = r_list.json()
     assert any(it["id"] == data["id"] for it in items)
+
+    r_delete = client.delete(
+        f"/stock/{data['id']}", headers={"Authorization": f"Bearer {token_admin}"}
+    )
+    assert r_delete.status_code == 200
+    assert r_delete.json() == {"deleted": True}
 
     r_forbidden = client.post(
         "/stock/",
@@ -46,15 +64,38 @@ def test_invoice_crud_and_permissions():
     token_user = make_token(["user"])
 
     payload = {"customer": "ACME", "total": 10.0}
-    r = client.post("/invoices/", json=payload, headers={"Authorization": f"Bearer {token_admin}"})
+    r = client.post(
+        "/invoices/", json=payload, headers={"Authorization": f"Bearer {token_admin}"}
+    )
     assert r.status_code == 200, r.text
     data = r.json()
     assert data["customer"] == "ACME"
 
-    r_list = client.get("/invoices/", headers={"Authorization": f"Bearer {token_admin}"})
+    r_get = client.get(
+        f"/invoices/{data['id']}", headers={"Authorization": f"Bearer {token_admin}"}
+    )
+    assert r_get.status_code == 200
+
+    r_update = client.put(
+        f"/invoices/{data['id']}",
+        json={"total": 20.0},
+        headers={"Authorization": f"Bearer {token_admin}"},
+    )
+    assert r_update.status_code == 200
+    assert r_update.json()["total"] == 20.0
+
+    r_list = client.get(
+        "/invoices/", headers={"Authorization": f"Bearer {token_admin}"}
+    )
     assert r_list.status_code == 200
     items = r_list.json()
     assert any(it["id"] == data["id"] for it in items)
+
+    r_delete = client.delete(
+        f"/invoices/{data['id']}", headers={"Authorization": f"Bearer {token_admin}"}
+    )
+    assert r_delete.status_code == 200
+    assert r_delete.json() == {"deleted": True}
 
     r_forbidden = client.post(
         "/invoices/",

--- a/docs/DATABASE_SCHEMA.md
+++ b/docs/DATABASE_SCHEMA.md
@@ -9,10 +9,12 @@
 - **license\_state**: licencia y estado local (modo limitado, última verificación).
 - **users**: credenciales e información de inicio de sesión.
 - **roles**: roles de acceso asignados a usuarios.
-- **stock**: inventario de artículos disponibles.
-- **invoices**: facturas internas asociadas a clientes.
+- **stock**: inventario de artículos (item, quantity, unit\_price).
+- **invoices**: facturas internas (customer, total, created\_at).
 - **cfdi_documents**: CFDI timbrados con enlaces a XML y PDF.
 - **subscriptions**: suscripciones de clientes a planes y proveedor.
+- **tax_config**: configuración fiscal (RFC, proveedor, actualizado).
+- **cfdi_pending**: CFDI pendientes de timbrar (cotización, total, estado, intentos).
 
 ## Relaciones
 
@@ -30,6 +32,8 @@ CREATE INDEX IF NOT EXISTS idx_vehicles_customer ON vehicles (customer_id);
 CREATE INDEX IF NOT EXISTS idx_quotes_customer ON quotes (customer_id);
 CREATE UNIQUE INDEX IF NOT EXISTS ux_quotes_approval_token ON quotes (approval_token);
 CREATE INDEX IF NOT EXISTS idx_attachments_wo ON attachments (work_order_id);
+CREATE INDEX IF NOT EXISTS idx_stock_item ON stock (item);
+CREATE INDEX IF NOT EXISTS idx_invoices_customer ON invoices (customer);
 ```
 
 ## Migraciones (Alembic)


### PR DESCRIPTION
## Summary
- index stock items and invoices customers for faster lookups
- document stock and invoice fields plus new indices
- cover full CRUD flows for stock and invoices

## Testing
- `pytest backend/tests/test_stock_invoice.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6c40e547c8333bff7aaa5b65e5a12