### PR TITLE
feat(cfdi): expand stamping validation and states

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -206,6 +206,7 @@ class CfdiDocumentORM(Base):
     total: Mapped[float] = mapped_column(Float, nullable=False)
     xml_url: Mapped[str] = mapped_column(String(1024), nullable=False)
     pdf_url: Mapped[str] = mapped_column(String(1024), nullable=False)
+    status: Mapped[str] = mapped_column(String(16), nullable=False, default="sent")
     created_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True, default=lambda: datetime.now(timezone.utc)
     )
@@ -218,6 +219,8 @@ class CfdiPendingORM(Base):
     quote_id: Mapped[str] = mapped_column(String(32), nullable=False)
     customer: Mapped[str] = mapped_column(String(255), nullable=False)
     total: Mapped[float] = mapped_column(Float, nullable=False)
+    rfc: Mapped[str] = mapped_column(String(64), nullable=False, default="XAXX010101000")
+    cfdi_use: Mapped[str] = mapped_column(String(8), nullable=False, default="P01")
     status: Mapped[str] = mapped_column(String(16), nullable=False, default="pending")
     attempts: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     last_error: Mapped[str | None] = mapped_column(String(255), nullable=True)

--- a/backend/tests/test_cfdi.py
+++ b/backend/tests/test_cfdi.py
@@ -26,13 +26,15 @@ def test_generate_cfdi(tmp_path, monkeypatch):
     headers = _auth_headers()
     payload = {
         "customer": "ACME",
+        "rfc": "XAXX010101000",
+        "cfdi_use": "P01",
         "items": [{"description": "Servicio", "quantity": 1, "unit_price": 100.0}],
     }
     resp = client.post("/cfdi/", json=payload, headers=headers)
     assert resp.status_code == 200
     data = resp.json()
     assert data["uuid"]
-    assert data["status"] == "generated"
+    assert data["status"] == "sent"
     assert data["xml_url"].startswith("file://")
     assert data["pdf_url"].startswith("file://")
 


### PR DESCRIPTION
## Summary
- validate RFC and CFDI use before stamping
- track stamping status through pending -> processing -> sent/failed
- document CFDI sandbox workflow and tests

## Testing
- `pytest backend/tests/test_cfdi.py backend/tests/test_cfdi_async.py backend/tests/test_cfdi_queue_retry.py`


------
https://chatgpt.com/codex/tasks/task_e_68a6c5f3ca0883339a72df0509dd6c18