### PR TITLE
Connect billing endpoints with portal and document webhooks

### DIFF
--- a/docs/BILLING_WEBHOOKS.md
+++ b/docs/BILLING_WEBHOOKS.md
@@ -1,6 +1,16 @@
 # Webhooks de facturación
 
-El backend expone un único endpoint para recibir eventos de facturación de los proveedores soportados.
+El backend expone endpoints para **gestionar suscripciones** y un único endpoint para recibir eventos de facturación de los proveedores soportados.
+
+## Endpoints de suscripción
+
+- `GET  /portal/api/billing/subscription?customer_id=<id>&plan_id=<id>`
+- `POST /portal/api/billing/subscribe` *(body: `{customer_id, plan_id}`)*
+- `POST /portal/api/billing/cancel` *(body: `{customer_id, plan_id}`)*
+
+La vista `/billing` del portal (React/Next.js) utiliza estos endpoints para dar de alta, cancelar y consultar el estado de las suscripciones.
+
+## Webhook
 
 ```
 POST /portal/api/billing/webhook

--- a/src/app/billing/page.tsx
+++ b/src/app/billing/page.tsx
@@ -51,7 +51,8 @@ export default function BillingPage() {
     })
     const data = await resp.json().catch(() => ({}))
     if (resp.ok) {
-      setStatus(data.status)
+      // Refrescar desde el backend para asegurar consistencia
+      await fetchStatus()
     } else {
       setStatus(null)
       setError(data.detail || 'Error')


### PR DESCRIPTION
## Summary
- document subscription endpoints and webhook usage
- refresh billing status from portal after subscribe/cancel
- test subscription lookup API

## Testing
- `npm test src` *(fails: Failed to resolve import "@internal/listenerMiddleware/utils" from node_modules/@reduxjs/toolkit/src/tests/...)*
- `npm run backend:test`


------
https://chatgpt.com/codex/tasks/task_e_68a715744ffc833382d55eaef562e50d